### PR TITLE
Update tagline and subtitle

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,9 +5,9 @@ remote_theme: "mmistakes/minimal-mistakes@4.24.0"
 locale: "en-US"
 title: ROHD
 title_separator: "-"
-# subtitle: "Framework"
+subtitle: "The Rapid Open Hardware Development Framework"
 email: "yao.jing.quek@intel.com"
-description: "The Rapid Open Hardware Development (ROHD) framework is a framework for describing and verifying hardware in the Dart programming language."
+description: "A better way to develop hardware The Rapid Open Hardware Development (ROHD) framework is a framework for describing and verifying hardware in the Dart programming language."
 url: "https://intel.github.io/rohd-website" # the base hostname & protocol for your site, e.g. http://example.com
 baseurl: "/rohd-website/" # the subpath of your site, e.g. /blog
 repository: "intel/rohd"

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -10,7 +10,7 @@ header:
     - label: "<i class='fas fa-cloud'></i> Try it in-browser"
       url: "https://dartpad.dev/?id=375e800a9d0bd402c9bfa5ebe2210c40"
 excerpt: >
-  The Rapid Open Hardware Development (ROHD) framework is a framework for describing and verifying hardware in the Dart programming language. <br />
+  A better way to develop hardware. <br />
   <small><a href="https://github.com/intel/rohd/releases">Latest release</a></small>
 feature_row:
   - image_path: assets/images/adobestock-312879613.jpeg


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Change the tagline to "A better way to develop hardware.", which is hopefully more inviting to visitors.  Also added a subtitle on the top so that we don't have to spell out the acronym with such big letters in the middle of the homepage.

## Related Issue(s)

N/A

## Testing

Ran locally

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? Are any links changing? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
