### PR TITLE
Update default permissions in GH actions

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+# Top-level default, no permissions
+permissions: {}
+
 jobs:
   run-checks:
     name: Run Checks

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -4,8 +4,14 @@ on:
     - cron: '5 8 * * 0' # Evry Sunday 8.05
   workflow_dispatch:
 
+# Top-level default, no permissions
+permissions: {}
+
 jobs:
   update_submodule:
+    permissions:
+      pull-requests: write
+      contents: write
     runs-on: ubuntu-22.04
     steps:
       - name: checkout repository

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -1,7 +1,7 @@
 name: update website
 on:
   schedule:
-    - cron: '5 8 * * 0' # Evry Sunday 8.05
+    - cron: '5 8 * * 0' # Every Sunday 8.05
   workflow_dispatch:
 
 # Top-level default, no permissions


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

It is safest to put a default permissions in GitHub Actions workflows.

## Related Issue(s)

N/A

## Testing

This PR will test the CI flow.  Auto PR will test via workflow dispatch.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? Are any links changing? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
