### PR TITLE
Fix Jekyll build of website

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -44,7 +44,10 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --source docs --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: |
+          cd docs
+          bundle install
+          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
       - name: Upload artifact

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build --source doc --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
       - name: Upload artifact

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -44,16 +44,14 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: |
-          cd doc
-          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build --source docs --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3
         with:
-          path: doc/_site
+          path: docs/_site
 
   # Deployment job
   deploy:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -44,12 +44,16 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --source doc --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: |
+          cd doc
+          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: doc/_site
 
   # Deployment job
   deploy:


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Recent changes in https://github.com/intel/rohd-website/pull/73 broke the build of the website due to white-listing limitations in GitHub pages (https://jekyllrb.com/docs/continuous-integration/github-actions/)

This PR migrates to using the actions to build the page instead of letting GitHub manage it.

## Related Issue(s)

<!-- If there are any issues related to this PR, please link to the issues here. -->

## Testing

Tested locally and in my own fork's main.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? Are any links changing? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No
