### PR TITLE
Ignore GitHub.com link checking due to rate limiting

### DIFF
--- a/.github/configs/mlc_config.json
+++ b/.github/configs/mlc_config.json
@@ -14,6 +14,9 @@
     },
     {
       "pattern":"^https://stackoverflow.com"
+    },
+    {
+      "pattern":"^https://github.com"
     }
   ]
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

GitHub started sending 429 errors due to rate limiting when we do link checking, so just ignore those (unfortunately) for now.
